### PR TITLE
Fix array conversion for shapely > 1.8

### DIFF
--- a/descartes/patch.py
+++ b/descartes/patch.py
@@ -41,8 +41,8 @@ def PolygonPath(polygon):
         vals[0] = Path.MOVETO
         return vals
     vertices = concatenate(
-                    [asarray(this.exterior)[:, :2]] 
-                    + [asarray(r)[:, :2] for r in this.interiors])
+                    [asarray(this.exterior.coords)[:, :2]] 
+                    + [asarray(r.coords)[:, :2] for r in this.interiors])
     codes = concatenate(
                 [coding(this.exterior)] 
                 + [coding(r) for r in this.interiors])


### PR DESCRIPTION
The array interface of Polygon is deprecated and will no longer work in Shapely 2.0. Convert the '.coords' to a numpy array instead.